### PR TITLE
chore/ci enable pages

### DIFF
--- a/.github/workflows/build-dashboard-artifact.yml
+++ b/.github/workflows/build-dashboard-artifact.yml
@@ -1,0 +1,69 @@
+name: Build dashboard data (artifact only)
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - '**.md'
+      - '.github/**'
+  schedule:
+    # UTC で 0,6,12,18 時に実行（JST: 09:00 / 15:00 / 21:00 / 03:00）
+    - cron: '0 */6 * * *'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}@${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '20.x'
+
+jobs:
+  build-and-upload:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+
+      - name: Install deps
+        run: npm ci
+
+      # プロジェクト差異に強いビルド判定（build:dashboard-data があれば優先）
+      - name: Build dashboard-data.json
+        shell: bash
+        run: |
+          set -euo pipefail
+          if npm run -s | grep -qE '^\s*build:dashboard-data'; then
+            npm run build:dashboard-data
+          elif npm run -s | grep -qE '^\s*build'; then
+            npm run build
+          else
+            echo "package.json に build:dashboard-data も build も見つかりません。" >&2
+            exit 1
+          fi
+
+      - name: Verify artifact exists
+        run: |
+          test -f docs/dashboard-data.json || {
+            echo "docs/dashboard-data.json が見つかりません。ビルドスクリプトを確認してください。" >&2
+            exit 1
+          }
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dashboard-data
+          path: docs/dashboard-data.json
+          retention-days: 14

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,22 +1,20 @@
-name: Build dashboard data (no Pages)
+name: Build dashboard data (artifact only)
 
 on:
-  workflow_dispatch:       # 手動実行だけ有効（必要なら push 条件を足せます）
-  # push:
-  #   branches: [ main ]
+  workflow_dispatch: {}
+  push:
+    branches: [ main, chore/ci-enable-pages ]
+    paths:
+      - "scripts/**"
+      - "package*.json"
+      - ".github/workflows/deploy-pages.yml"
 
 permissions:
   contents: read
 
-concurrency:
-  group: build-dashboard-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   build:
-    name: Generate dashboard data
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -25,91 +23,24 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: npm
 
-      - name: Install Dependencies
+      - name: Install dependencies
         run: npm ci
 
-      - name: Generate Dashboard Data
+      - name: Generate dashboard data
         env:
-          # スクリプトが参照する想定の環境変数（必要なければ削除可）
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_PROJECT_NUMBER: 1
-        run: npx tsx scripts/generate-dashboard-data.ts
+        run: |
+          npx tsx scripts/generate-dashboard-data.ts
+          ls -l docs || true
+          head -n 50 docs/dashboard-data.json || true
 
-      - name: Upload artifact (dashboard-data.json)
+      - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: dashboard-data
           path: docs/dashboard-data.json
           if-no-files-found: error
-name: Deploy GitHub Pages
-
-on:
-  workflow_dispatch:
-  schedule:
-    - cron: '0 */6 * * *'  # 任意（今まで通り定期実行したい場合）
-
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-concurrency:
-  group: "pages"
-  cancel-in-progress: true
-
-jobs:
-  generate:
-    if: ${{ github.event_name == 'workflow_dispatch' && github.repository_owner == 'matsu8org' }}
-    name: Generate dashboard data
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: Install Dependencies
-        run: npm ci
-
-      - name: Generate Dashboard Data
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          GITHUB_PROJECT_NUMBER: 1
-        run: npx tsx scripts/generate-dashboard-data.ts
-
-      - name: Upload Dashboard Data
-        uses: actions/upload-artifact@v4
-        with:
-          name: dashboard-data
-          path: docs/dashboard-data.json
-
-#  deploy:
-#    name: Deploy to GitHub Pages
-#    needs: generate
-#    runs-on: ubuntu-24.04
-#    steps:
-#      - uses: actions/checkout@v4
-#
-#      - name: Download Dashboard Data
-#        uses: actions/download-artifact@v4
-#        with:
-#          name: dashboard-data
-#          path: docs/
-#
-#      - name: Setup Pages
-#        uses: actions/configure-pages@v4
-#        with:
-#          enablement: true  # ← これで未有効でも自動で有効化
-#
-#      - name: Upload Pages artifact
-#        uses: actions/upload-pages-artifact@v3
-#        with:
-#          path: docs  # ← 公開する中身（今回 docs/ 配下）
-#
-#      - name: Deploy to Pages
-#        id: deployment
-#        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,3 +1,48 @@
+name: Build dashboard data (no Pages)
+
+on:
+  workflow_dispatch:       # 手動実行だけ有効（必要なら push 条件を足せます）
+  # push:
+  #   branches: [ main ]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: build-dashboard-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Generate dashboard data
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Generate Dashboard Data
+        env:
+          # スクリプトが参照する想定の環境変数（必要なければ削除可）
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_PROJECT_NUMBER: 1
+        run: npx tsx scripts/generate-dashboard-data.ts
+
+      - name: Upload artifact (dashboard-data.json)
+        uses: actions/upload-artifact@v4
+        with:
+          name: dashboard-data
+          path: docs/dashboard-data.json
+          if-no-files-found: error
 name: Deploy GitHub Pages
 
 on:
@@ -16,6 +61,7 @@ concurrency:
 
 jobs:
   generate:
+    if: ${{ github.event_name == 'workflow_dispatch' && github.repository_owner == 'matsu8org' }}
     name: Generate dashboard data
     runs-on: ubuntu-24.04
     steps:
@@ -41,29 +87,29 @@ jobs:
           name: dashboard-data
           path: docs/dashboard-data.json
 
-  deploy:
-    name: Deploy to GitHub Pages
-    needs: generate
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Download Dashboard Data
-        uses: actions/download-artifact@v4
-        with:
-          name: dashboard-data
-          path: docs/
-
-      - name: Setup Pages
-        uses: actions/configure-pages@v4
-        with:
-          enablement: true  # ← これで未有効でも自動で有効化
-
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: docs  # ← 公開する中身（今回 docs/ 配下）
-
-      - name: Deploy to Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+#  deploy:
+#    name: Deploy to GitHub Pages
+#    needs: generate
+#    runs-on: ubuntu-24.04
+#    steps:
+#      - uses: actions/checkout@v4
+#
+#      - name: Download Dashboard Data
+#        uses: actions/download-artifact@v4
+#        with:
+#          name: dashboard-data
+#          path: docs/
+#
+#      - name: Setup Pages
+#        uses: actions/configure-pages@v4
+#        with:
+#          enablement: true  # ← これで未有効でも自動で有効化
+#
+#      - name: Upload Pages artifact
+#        uses: actions/upload-pages-artifact@v3
+#        with:
+#          path: docs  # ← 公開する中身（今回 docs/ 配下）
+#
+#      - name: Deploy to Pages
+#        id: deployment
+#        uses: actions/deploy-pages@v4


### PR DESCRIPTION
- **chore: init threadsWR**
- **chore(ci): track package-lock.json for reproducible builds**
- **chore(ci): add stub scripts/generate-dashboard-data.ts for Pages job**
- **ci: output dashboard to docs/dashboard-data.json to match workflow**
- **ci: enable Pages & deploy docs/ via Actions**
- **ci: remove GitHub Pages deploy and keep artifact only**
